### PR TITLE
Fix credentials stored in Docker images

### DIFF
--- a/emu/Dockerfile
+++ b/emu/Dockerfile
@@ -15,13 +15,6 @@ COPY pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 RUN pnpm install onnxruntime-node@1.14.0
 
-# Set the Pinecone env vars explicitly, otherwise we'll get a build error
-ARG PINECONE_API_KEY
-ARG PINECONE_ENVIRONMENT
-
-ENV PINECONE_API_KEY=$PINECONE_API_KEY
-ENV PINECONE_ENVIRONMENT=$PINECONE_ENVIRONMENT
-
 # Copy the rest of the app's source code to the working directory
 COPY . .
 

--- a/index.ts
+++ b/index.ts
@@ -221,17 +221,6 @@ const frontendImage = new docker.Image('frontend-image', {
   build: {
     platform: "linux/amd64",
     context: "./semantic-search-postgres/",
-    dockerfile: "./semantic-search-postgres/Dockerfile",
-    args: {
-      "PINECONE_API_KEY": `${process.env.PINECONE_API_KEY}`,
-      "PINECONE_ENVIRONMENT": `${process.env.PINECONE_ENVIRONMENT}`,
-      "PINECONE_INDEX": `${process.env.PINECONE_INDEX}`,
-      "POSTGRES_DB_NAME": `postgres`,
-      "POSTGRES_DB_HOST": dbAddress.apply(a => a),
-      "POSTGRES_DB_PORT": targetDbPort.toString(),
-      "POSTGRES_DB_USER": `${process.env.POSTGRES_DB_USER}`,
-      "POSTGRES_DB_PASSWORD": dbSnapshotPassword,
-    },
   },
   imageName: frontendRepo.repositoryUrl,
   registry: frontendRegistryInfo,
@@ -246,16 +235,6 @@ const pelicanImage = new docker.Image("pelican-image", {
   build: {
     platform: "linux/amd64",
     context: "./pelican",
-    dockerfile: "./pelican/Dockerfile",
-    args: {
-      "POSTGRES_DB_NAME": `postgres`,
-      "POSTGRES_DB_HOST": dbAddress.apply(a => a),
-      "POSTGRES_DB_PORT": targetDbPort.toString(),
-      "POSTGRES_DB_USER": `postgres`,
-      "POSTGRES_DB_PASSWORD": dbSnapshotPassword,
-      "AWS_REGION": `${process.env.AWS_REGION}` || 'us-east-1',
-      "SQS_QUEUE_URL": `${process.env.SQS_QUEUE_URL}`
-    }
   },
   imageName: pelicanRepo.repositoryUrl,
   registry: registryInfo,
@@ -269,14 +248,6 @@ const emuImage = new docker.Image("emu-image", {
   build: {
     platform: "linux/amd64",
     context: "./emu",
-    dockerfile: "./emu/Dockerfile",
-    args: {
-      "PINECONE_INDEX": `${process.env.PINECONE_INDEX}`,
-      "PINECONE_API_KEY": `${process.env.PINECONE_API_KEY}`,
-      "PINECONE_ENVIRONMENT": `${process.env.PINECONE_ENVIRONMENT}`,
-      "AWS_REGION": `${process.env.AWS_REGION}` || 'us-east-1',
-      "SQS_QUEUE_URL": `${process.env.SQS_QUEUE_URL}`
-    }
   },
   imageName: emuRepo.repositoryUrl,
   registry: emuRegistryInfo,

--- a/pelican/Dockerfile
+++ b/pelican/Dockerfile
@@ -27,24 +27,5 @@ WORKDIR /usr/src/app
 COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/dist ./dist
 
-# Define build arguments for environment variables
-ARG POSTGRES_DB_USER
-ARG POSTGRES_DB_HOST
-ARG POSTGRES_DB_NAME
-ARG POSTGRES_DB_PASSWORD
-ARG POSTGRES_DB_PORT
-ARG CERTIFICATE_BASE64
-ARG EMU_ENDPOINT
-
-# Set environment variables from build arguments
-ENV POSTGRES_DB_USER=$POSTGRES_DB_USER
-ENV POSTGRES_DB_HOST=$POSTGRES_DB_HOST
-ENV POSTGRES_DB_NAME=$POSTGRES_DB_NAME
-ENV POSTGRES_DB_PASSWORD=$POSTGRES_DB_PASSWORD
-ENV POSTGRES_DB_PORT=$POSTGRES_DB_PORT
-ENV CERTIFICATE_BASE64=$CERTIFICATE_BASE64
-ENV EMU_ENDPOINT=$EMU_ENDPOINT
-
 # Start the application
 CMD ["node", "dist/index.js"]
-

--- a/semantic-search-postgres/Dockerfile
+++ b/semantic-search-postgres/Dockerfile
@@ -30,12 +30,6 @@ COPY --link  . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 # ENV NEXT_TELEMETRY_DISABLED 1
 
-# TODO: this is unfortunate, but it appears that if the PINECONE_API_KEY and PINECONE_ENVIRONMENT 
-# variables are not set here, then the app build (npm run build) will fail within the container
-# because our client expects these values to at least be present
-ARG PINECONE_API_KEY
-ARG PINECONE_ENVIRONMENT
-
 RUN npm run build
 
 # If using yarn comment out above and use below instead

--- a/semantic-search-postgres/src/app/api/products/route.js
+++ b/semantic-search-postgres/src/app/api/products/route.js
@@ -5,14 +5,28 @@ import { NextResponse } from 'next/server'
 import logger from '../../logger';
 import worker_id from '../../workerIdSingleton'
 
-const pinecone = new Pinecone({
-  apiKey: process.env.PINECONE_API_KEY,
-  environment: process.env.PINECONE_ENVIRONMENT,
-});
+// This cannot be served at build time.
+export const dynamic = 'force-dynamic';
+
+/** @type Pinecone */
+let pinecone
+function getPinecone() {
+  if (pinecone) {
+    return pinecone;
+  }
+  pinecone = new Pinecone({
+    apiKey: process.env.PINECONE_API_KEY,
+    environment: process.env.PINECONE_ENVIRONMENT,
+  });
+  return pinecone;
+}
+
 const limit = 10;
 
 async function handler(req) {
   const { searchTerm, currentPage } = await req.json();
+
+  const pinecone = getPinecone();
 
   console.log(`searchTerm: ${searchTerm}, currentPage: ${currentPage}`);
 

--- a/semantic-search-postgres/src/utils/db.ts
+++ b/semantic-search-postgres/src/utils/db.ts
@@ -1,26 +1,30 @@
 import { Pool } from "pg";
 
+let pool: Pool
 // Initialize the pool
-const pool = new Pool({
-    host: process.env.POSTGRES_DB_HOST,
-    port: Number(process.env.POSTGRES_DB_PORT || "5432"),
-    database: process.env.POSTGRES_DB_NAME,
-    user: process.env.POSTGRES_DB_USER,
-    password: process.env.POSTGRES_DB_PASSWORD,
-    ssl: {
-        rejectUnauthorized: false,
-    },
-});
+function getPool() {
+    if (pool) return pool;
+
+    pool = new Pool({
+        host: process.env.POSTGRES_DB_HOST,
+        port: Number(process.env.POSTGRES_DB_PORT || "5432"),
+        database: process.env.POSTGRES_DB_NAME,
+        user: process.env.POSTGRES_DB_USER,
+        password: process.env.POSTGRES_DB_PASSWORD,
+        ssl: {
+            rejectUnauthorized: false,
+        },
+    });
+
+    return pool;
+}
 
 // Query function to execute database queries
 export const query = async (text: string, params?: any[]) => {
-    const client = await pool.connect();
+    const client = await getPool().connect();
     try {
         return await client.query(text, params);
     } finally {
         client.release();
     }
 };
-
-// Export pool for additional operations if necessary
-export const dbPool = pool;


### PR DESCRIPTION
Fixes #55

When env vars are used to construct values in Next.js, a "const" declared at the
top level may be evaluated at build time, runtime by the server, or - in the
case of client components - runtime by the browser.

The PINECONE_API_KEY and PINECONE_ENVIRONMENT variables here need to be deferred
to runtime, and not used in static rendering. We put the constructor for
Pinecone behind a getter, which ensures `process.env.$KEY` is evaluated at
runtime.

We also mark the route as dynamic, this can be used by Next.js to defer
rendering of components that might call this route as well.